### PR TITLE
fix GoogleMap.vue

### DIFF
--- a/app/javascript/components/GoogleMap.vue
+++ b/app/javascript/components/GoogleMap.vue
@@ -248,6 +248,7 @@ export default {
     createMap() {
       const target = document.getElementById("target");
       const mapOptions = {
+        gestureHandling: 'greedy',
         center: this.center,
         zoom: this.zoom,
         disableDefaultUI: true,


### PR DESCRIPTION
スマホで閲覧したときの「地図を移動させるには指２本で操作します」を解除