### PR TITLE
hotfix: createFlash GoogleMaps is beta

### DIFF
--- a/app/javascript/components/GoogleMap.vue
+++ b/app/javascript/components/GoogleMap.vue
@@ -76,6 +76,7 @@ export default {
     this.mapWidth = window.innerWidth;
     this.mapHeight = window.innerHeight - 112;
     this.setLocations();
+    this.createFlash({type: "info", message: "現在β版です（ユーザーレビュー反映中）"})
   },
   mounted() {
     this.createMap();


### PR DESCRIPTION
# 概要
- My定番スポット画面を開くと「現在β版です（ユーザーレビュー反映中）」とFlashが出るよう応急処置